### PR TITLE
Corrected location of parenthesis

### DIFF
--- a/inc/metaboxes/init.php
+++ b/inc/metaboxes/init.php
@@ -753,7 +753,7 @@ class cmb_Meta_Box {
 		elseif ( is_string( $meta_box['pages'] ) )
 			$type = $meta_box['pages'];
 		// if it's an array of one, extract it
-		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] === 1 ) )
+		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] ) === 1 )
 			$type = is_string( end( $meta_box['pages'] ) ) ? end( $meta_box['pages'] ) : false;
 
 		if ( !$type )


### PR DESCRIPTION
To prevent "count(): Parameter must be an array or an object that implements Countable" warnings